### PR TITLE
Append prefix to UI's Env Vars

### DIFF
--- a/packages/ui/.env.development.example
+++ b/packages/ui/.env.development.example
@@ -1,6 +1,6 @@
-SKIP_PREFLIGHT_CHECK=true
-ApiEndpoint=https://wjiplwvjc5hprnhgm2sfd6q34u.appsync-api.us-west-2.amazonaws.com/graphql
-CognitoIdentityPoolId=ap-south-1:89d2a625-af3c-43b1-bba6-f5b309c14b83
-CognitoUserPoolId=ap-south-1_AnYbk8zYQ
-CognitoUserPoolClientId=2cq2c6gs5fqucqjobedacduilk
-Region=ap-south-1
+NEXT_PUBLIC_SKIP_PREFLIGHT_CHECK=true
+NEXT_PUBLIC_ApiEndpoint=https://wjiplwvjc5hprnhgm2sfd6q34u.appsync-api.us-west-2.amazonaws.com/graphql
+NEXT_PUBLIC_CognitoIdentityPoolId=ap-south-1:89d2a625-af3c-43b1-bba6-f5b309c14b83
+NEXT_PUBLIC_CognitoUserPoolId=ap-south-1_AnYbk8zYQ
+NEXT_PUBLIC_CognitoUserPoolClientId=2cq2c6gs5fqucqjobedacduilk
+NEXT_PUBLIC_Region=ap-south-1


### PR DESCRIPTION
Updated: `.env.development.example`

Environment variables are not detected on UI unless we add the prefix.