### PR TITLE
Add send Email support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 SERVERLESS_SERVICE_SUFFIX=
 ALARMS_NOTIFICATION_EMAIL=alert@example.com
 NODE_ENV=production
+CONTACT_SP_EMAIL=alert@example.com
+SOURCE_EMAIL=alert@example.com
+CONFIG_SET_NAME=alert@example.com

--- a/packages/api/controllers/task.js
+++ b/packages/api/controllers/task.js
@@ -1,10 +1,13 @@
 import sanitizeHtml from 'sanitize-html'
+import AWS from 'aws-sdk'
 import Task from '../models/Task'
 import { generateId } from '../utils/id'
 import { log } from '../utils/logger'
 import { getUser } from './user'
 import { TASK_STATUSES } from '../common/constant'
 import NotFoundError from '../errors/NotFoundError'
+
+AWS.config.update({})
 
 export async function createTask({
   userId,
@@ -111,4 +114,49 @@ export async function deleteTask({ projectId, taskId }) {
   const task = await Task.get({ projectId, taskId })
   if (!task) throw NotFoundError('Program can not be found')
   await Task.delete({ projectId, taskId })
+}
+
+export async function sendContactSPEmail({
+  message, userId, task, spName,
+}) {
+  const user = await getUser({ userId })
+  const ses = new AWS.SES({ apiVersion: '2010-12-01' })
+  const params = {
+    Destination: {
+      ToAddresses: [process.env.CONTACT_SP_EMAIL],
+    },
+    ConfigurationSetName: process.env.CONFIG_SET_NAME,
+    Message: {
+      Body: {
+        Html: {
+          Charset: 'UTF-8',
+          Data:
+          `
+          <html>
+            <body>
+              <h3>New message from Customer ${user.name} to service provider ${spName}</h3>
+              <h3>Message: ${message}</h3>
+              <h3>Task Name: ${task.name}, TaskId: ${task.taskId}</h3>
+            </body>
+          </html>
+          `,
+        },
+        Text: {
+          Charset: 'UTF-8',
+          Data: `New message from Customer ${user.name} to service provider ${spName}`,
+        },
+      },
+      Subject: {
+        Charset: 'UTF-8',
+        Data: `New message from Customer ${user.name} to service provider ${spName}`,
+      },
+    },
+    Source: process.env.SOURCE_EMAIL,
+  }
+  try {
+    await ses.sendEmail(params)
+      .promise()
+  } catch (e) {
+    throw new Error('Email Was not sent')
+  }
 }

--- a/packages/api/functions/express/routes/task.js
+++ b/packages/api/functions/express/routes/task.js
@@ -5,7 +5,7 @@ import {
   getTask,
   updateTask,
   getTasks,
-  deleteTask,
+  deleteTask, sendContactSPEmail,
 } from '../../../controllers/task'
 
 const taskRouter = express.Router({ mergeParams: true })
@@ -17,6 +17,15 @@ taskRouter.post('/', wrapAsync(async (req, res) => {
   const taskItem = await createTask({ userId, projectId, task })
 
   res.json({ task: taskItem })
+}))
+
+taskRouter.post('/:taskId/contactUs', wrapAsync(async (req, res) => {
+  const { message, spName, task } = req.body
+  const { userId } = req.cognitoUser
+  await sendContactSPEmail({
+    message, task, userId, spName,
+  })
+  res.json({})
 }))
 
 taskRouter.put('/:taskId', wrapAsync(async (req, res) => {

--- a/packages/ui/components/ContactServiceProviderModal/index.tsx
+++ b/packages/ui/components/ContactServiceProviderModal/index.tsx
@@ -1,9 +1,46 @@
-import { Button, Col, Form, Input, Modal, Row, Space } from 'antd'
+import {
+  Button,
+  Col,
+  Form,
+  Input,
+  Modal,
+  notification,
+  Row,
+  Space,
+} from 'antd'
+import { useMutation } from 'react-query'
+import axios from 'axios'
 
 export default function ContactServiceProviderModal({
   visible,
   hide,
+  serviceProvider,
+  task,
 }) {
+  const contactMutation = useMutation(
+    (message) =>
+      axios.post(
+        `/projects/${task.projectId}/tasks/${task.taskId}/contactUs`,
+        { message, task, spName: serviceProvider.name },
+      ),
+    {
+      onSuccess: async () => {
+        notification.success({
+          duration: 2,
+          message: `Message has been sent successfully`,
+        })
+      },
+      onError: (err: Error) =>
+        notification.error({
+          duration: 2,
+          message: `Message was not sent`,
+          description: err.message,
+        }),
+    },
+  )
+
+  const onFinish = ({ message }) => contactMutation.mutate(message)
+
   return (
     <Modal
       centered
@@ -39,11 +76,14 @@ export default function ContactServiceProviderModal({
             direction="vertical"
             style={{ width: '100%', height: '100%' }}
           >
-            <h1>Send Message to Charles River</h1>
+            <h1>
+              Send Message to
+              {` ${serviceProvider.name}`}
+            </h1>
             <b>Briefly describe what you want to discuss</b>
-            <Form layout="vertical">
+            <Form layout="vertical" onFinish={onFinish}>
               <Form.Item
-                name="description"
+                name="message"
                 required={false}
                 rules={[
                   {
@@ -58,7 +98,12 @@ export default function ContactServiceProviderModal({
                   required={false}
                 />
               </Form.Item>
-              <Button block htmlType="submit" type="primary">
+              <Button
+                loading={contactMutation.isLoading}
+                block
+                htmlType="submit"
+                type="primary"
+              >
                 Send
               </Button>
             </Form>

--- a/packages/ui/components/Pages/Questionaire/QuestionnaireResult.tsx
+++ b/packages/ui/components/Pages/Questionaire/QuestionnaireResult.tsx
@@ -47,7 +47,7 @@ export default function QuestionnaireResult({
         const program = resp?.data?.program
         notification.success({
           duration: 2,
-          message: 'Program created Successfully',
+          message: 'Program created successfully',
         })
         await queryClient.invalidateQueries('defaultWorkspace')
         await router.push(

--- a/packages/ui/components/ServiceProvider/index.tsx
+++ b/packages/ui/components/ServiceProvider/index.tsx
@@ -22,7 +22,7 @@ const Container = styled(Space)`
   }
 `
 
-export default function ServiceProvider({ serviceProvider }) {
+export default function ServiceProvider({ serviceProvider, task }) {
   const [isModalVisible, setIsModalVisible] = useState(false)
   return (
     <Container>
@@ -49,6 +49,8 @@ export default function ServiceProvider({ serviceProvider }) {
         Reach out
       </Button>
       <ContactServiceProviderModal
+        task={task}
+        serviceProvider={serviceProvider}
         visible={isModalVisible}
         hide={() => setIsModalVisible(false)}
       />

--- a/packages/ui/components/ServiceProviderCard/index.tsx
+++ b/packages/ui/components/ServiceProviderCard/index.tsx
@@ -2,7 +2,8 @@ import { Button, Card } from 'antd'
 import React, { useState } from 'react'
 import ServiceProvider from 'components/ServiceProvider'
 
-export default function ServiceProviderCard({ serviceProviders }) {
+export default function ServiceProviderCard({ task }) {
+  const { serviceProviders } = task
   const [showAllSps, setShowAllSps] = useState(false)
   return (
     <Card title="Connect with Service Providers" bordered={false}>
@@ -11,6 +12,7 @@ export default function ServiceProviderCard({ serviceProviders }) {
         if (index < 3 || showAllSps)
           return (
             <ServiceProvider
+              task={task}
               key={serviceProvider.serviceProviderId}
               serviceProvider={serviceProvider}
             />

--- a/packages/ui/pages/tasks/[[...id]].tsx
+++ b/packages/ui/pages/tasks/[[...id]].tsx
@@ -213,9 +213,7 @@ export default function TaskDetails() {
               <Col span={8}>
                 {task?.guide && <TaskGuideCard guide={task?.guide} />}
                 {task?.serviceProviders && (
-                  <ServiceProviderCard
-                    serviceProviders={task?.serviceProviders}
-                  />
+                  <ServiceProviderCard task={task} />
                 )}
               </Col>
             </Row>

--- a/templates/functions.yml
+++ b/templates/functions.yml
@@ -46,6 +46,14 @@ express:
           - !GetAtt ProjectTable.Arn
           - !GetAtt ProgramTable.Arn
           - !GetAtt OrganizationTable.Arn
+      - Effect: "Allow"
+        Action:
+          - "SNS:Publish"
+          - "SES:Publish"
+          - "SES:SendEmail"
+          - "SES:SendRawEmail"
+        Resource:
+          - "*"
 
 postAuthN:
   handler: packages/api/functions/cognito/post-authentication.handler


### PR DESCRIPTION
*Description of changes:*

- Add SES and SNS permission to serverless config
- Send an Email to the administrator upon user request to contact the service provider (check task details screen)

# Checklist

- [ ] Tests have been added and are passing
- [ ] Documentation has been updated

# Note: 
- Make sure to update `.env.development` file with new configuration entries. 
```
CONTACT_SP_EMAIL=alert@example.com
SOURCE_EMAIL=alert@example.com
CONFIG_SET_NAME=alert@example.com
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.